### PR TITLE
Implement T2 for also delaying transmit of I frames

### DIFF
--- a/src/bbs/etc/Config
+++ b/src/bbs/etc/Config
@@ -240,7 +240,8 @@ PORT	STATUS	SYSTEM	FALSE	FALSE	Status
 ;	tncd only knows when the frame was sent to the tnc, not when it
 ;	was actually transmitted.
 ;
-; T2: How long to wait after receiving a packet before you confirm.
+; T2: How long to wait after receiving a packet or wishing to transmit
+;	frames before initiating a transmit.
 ;
 ; T3: How often to ping the remote station to see if it is still there
 ;	when idle.

--- a/src/bbs/tncd/ax25.h
+++ b/src/bbs/tncd/ax25.h
@@ -177,7 +177,7 @@ extern int
 extern void
 	recover(int *n),
 	pollthem(int *n),
-	send_ack(int *n),
+	send_data(int *n),
 	lapbstate(struct ax25_cb *axp, int s),
 	est_link(struct ax25_cb *axp);
 extern void

--- a/src/bbs/tncd/ax25subr.c
+++ b/src/bbs/tncd/ax25subr.c
@@ -129,7 +129,7 @@ cr_ax25(kiss *dev, struct ax25_addr *my_addr, struct ax25_addr *their_addr)
 	axp->t1.arg = (char *)axp;
 
 	axp->t2.start = Tncd_T2init;
-	axp->t2.func = send_ack;
+	axp->t2.func = send_data;
 	axp->t2.arg = (char *)axp;
 
 	axp->t3.start = Tncd_T3init;

--- a/src/bbs/tncd/ax25user.c
+++ b/src/bbs/tncd/ax25user.c
@@ -70,6 +70,7 @@ send_ax25(struct ax25_cb *axp, struct mbuf *bp)
 	if (!run_timer(&axp->t2)) {
 		start_timer(&axp->t2);
 	}
+	return 0;
 }
 
 /* Receive incoming data on an AX.25 connection */

--- a/src/bbs/tncd/ax25user.c
+++ b/src/bbs/tncd/ax25user.c
@@ -86,8 +86,12 @@ recv_ax25(struct ax25_cb *axp)
 	axp->rxq = NULLBUF;
 
 	/* If this has un-busied us, send a RR to reopen the window */
-	if(len_mbuf(bp) >= axp->window)
-		sendctl(axp,RESPONSE,RR);
+	if(len_mbuf(bp) >= axp->window) {
+		if (! run_timer(&axp->t2)) {
+			axp->response = RR;
+			start_timer(&axp->t2);
+		}
+	}
 	return bp;
 }
 

--- a/src/bbs/tncd/ax25user.c
+++ b/src/bbs/tncd/ax25user.c
@@ -65,7 +65,11 @@ send_ax25(struct ax25_cb *axp, struct mbuf *bp)
 	if(axp == NULLAX25 || bp == NULLBUF)
 		return -1;
 	enqueue(&axp->txq,bp);
-	return lapb_output(axp);
+
+	/* Kick the send timer */
+	if (!run_timer(&axp->t2)) {
+		start_timer(&axp->t2);
+	}
 }
 
 /* Receive incoming data on an AX.25 connection */

--- a/src/bbs/tncd/lapb.c
+++ b/src/bbs/tncd/lapb.c
@@ -509,7 +509,7 @@ lapb_output(struct ax25_cb *axp)
 		if (!run_timer(&axp->t1)) {
 			start_timer(&axp->t1);
 		}
-		return;
+		return 0;
 	}
 
 	/* Dig into the send queue for the first unsent frame */

--- a/src/bbs/tncd/lapbtime.c
+++ b/src/bbs/tncd/lapbtime.c
@@ -94,7 +94,7 @@ send_data(int *n)
 	 * they need to go out now.
 	 */
 	if (axp->response != 0) {
-		sendctl(axp,LAPB_RESPONSE,axp->response);
+		sendctl(axp,RESPONSE,axp->response);
 		axp->response = 0;
 	}
 }

--- a/src/bbs/tncd/lapbtime.c
+++ b/src/bbs/tncd/lapbtime.c
@@ -121,6 +121,7 @@ static void
 tx_enq(struct ax25_cb *axp)
 {
 	char ctl;
+#if 0
 	struct mbuf *bp;
 
 	/* I believe that retransmitting the oldest unacked
@@ -140,6 +141,17 @@ tx_enq(struct ax25_cb *axp)
 		ctl = len_mbuf(axp->rxq) >= axp->window ? RNR|PF : RR|PF;	
 		sendctl(axp,COMMAND,ctl);
 	}
+#else
+	/*
+	 * Don't try to do the above; if you're unlucky then you'll
+	 * end up burning TX time to send both a very outdated I
+	 * frame /and/ have the remote end reply with a REJ for
+	 * now-stale data.  Just send a poll for now and revisit this
+	 * optimisation at a later date.
+	 */
+	ctl = len_mbuf(axp->rxq) >= axp->window ? RNR|PF : RR|PF;
+	sendctl(axp,COMMAND,ctl);
+#endif
 	axp->response = 0;	
 	stop_timer(&axp->t3);
 	start_timer(&axp->t1);

--- a/src/bbs/tncd/monitor.c
+++ b/src/bbs/tncd/monitor.c
@@ -44,7 +44,7 @@ char *helpmsg[] = {
 	"STatus ........ show status of all procs\n",
 	"SEt ........... set tnc parameters\n",
 	"   T1 30\n",
-	"   T2 4\n",
+	"   T2 3\n",
 	"   T3 300\n",
 	"   MAXFRAME 7\n",
 	"   PACLEN 220\n",


### PR DESCRIPTION
This work brings n0ary into line with what jnos2 does - use T2 for both I+S frame transmit when not responding to polls.

This does slow down data bursts somewhat as data isn't immediately transmitted when queued, however it does mean that now data transmit, RR/RNR transmit and handling RR/REJ is less likely to cause queues of massive amounts of retransmissions to be sent out a TNC.

I'm interested in reviews right now; I plan on adding a couple more changes to this patch set before I officially want it tested. :-)
