### PR TITLE
Clean up scripts and naming.

### DIFF
--- a/src/scripts/init-bbs.sh
+++ b/src/scripts/init-bbs.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# create user GATEWY
-# unmark as BBS
-# set help level to 0
-# unset nonham
-# set approved

--- a/src/scripts/scripts.mk
+++ b/src/scripts/scripts.mk
@@ -12,13 +12,15 @@ BSD_AUTOMATED_DIR ?= /usr/local/libexec
 SCRIPTS_INSTALL:
 	install -d $(BSD_STARTUP_DIR)
 	for sc in $(STARTUP_SCRIPTS_SRCS); do \
+		shless=$$( basename $$sc .sh ); \
 		sed -e s,XXBBS_DIRXX,$(BBS_DIR), < $(SCRIPTS_SRCDIR)/$$sc \
-		> $(BSD_STARTUP_DIR)/$$sc; \
-		chmod 755 $(BSD_STARTUP_DIR)/$$sc; \
+		> $(BSD_STARTUP_DIR)/$$shless; \
+		chmod 755 $(BSD_STARTUP_DIR)/$$shless; \
 	done
 	install -d $(BSD_AUTOMATED_DIR)
 	for sc in $(AUTOMATED_SCRIPTS_SRCS); do \
+		shless=$$( basename $$sc .sh ); \
 		sed -e s,XXBBS_DIRXX,$(BBS_DIR), < $(SCRIPTS_SRCDIR)/$$sc \
-		> $(BSD_AUTOMATED_DIR)/$$sc; \
-		chmod 755 $(BSD_AUTOMATED_DIR)/$$sc; \
+		> $(BSD_AUTOMATED_DIR)/$$shless; \
+		chmod 755 $(BSD_AUTOMATED_DIR)/$$shless; \
 	done


### PR DESCRIPTION
Remove redundant initialization script and change script installation process so that scripts are installed without the ".sh" extension. This is useful primarily for integration with the FreeBSD "service" utility, which can't find a service if its startup script ends in ".sh".