### PR TITLE
Feature: AX.25/KISS PCAP logging

### DIFF
--- a/src/bbs/etc/Config
+++ b/src/bbs/etc/Config
@@ -343,6 +343,27 @@ TNC	TNC3	44453	44463	/dev/ttyb  bbshost 10  4 300 7   220  5  0
 ; TNC0_KISS_MUX_BIND_ADDR     (not set, defaults to 127.0.0.1)
 ; TNC0_KISS_MUX_PORT          (not set, defaults to 0, disabling feature)
 ; TNC0_KISS_MUX_SEE_OTHERS    (not set, defaults to 1)
+;
+;     PCAP log/dump files
+;
+;  If PCAP dumping is enabled for a TNC, then all packets received and
+;  transmitted on that TNC will be written to a tcpdump.org comptatible
+;  packet capture file, using the "KISS" dump format. These capture files
+;  can be inspected using a tool like "WireShark", to audit what was received
+;  and transmitted on the TNC and possibly help debug connection issues
+;  (or even protocol bugs in the BBS!).
+;
+;  To enable PCAP dumping, set the TNCx_PCAP_DUMP_PATH variable to the
+;  full filesystem path you would like the session for that TNC to be
+;  captured to.
+;
+;  PCAP capture files are cumulative, which means that any existing packets
+;  found in the file will be preserved at startup. New packets are simply
+;  appended to the file. So it is safe to restart any particular TNC as
+;  many times as you like, and to keep the same PCAP file in place for
+;  days (or even years), if you care.
+;
+; TNC0_PCAP_DUMP_PATH (not set, defaults to empty, and thus, disabled)
 
 
 ;###

--- a/src/bbs/tncd/kiss.c
+++ b/src/bbs/tncd/kiss.c
@@ -106,7 +106,7 @@ kiss_set_pcap_dump(kiss *kiss, FILE *fp)
 		return -1;
 	}
 
-	if (ftell(fp) != 0) {
+	if (ftell(fp) == 0) {
 		if ((res = kiss_write_pcap_header(fp)) != 0) {
 			return res;
 		}

--- a/src/bbs/tncd/kiss.c
+++ b/src/bbs/tncd/kiss.c
@@ -1,3 +1,5 @@
+#include <sys/time.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 #include "c_cmmn.h"
@@ -7,6 +9,7 @@
 #include "slip.h"
 #include "timer.h"
 #include "ax25.h"
+#include "kiss_pcap.h"
 
 /* KISS TNC control */
 #define	KISS_DATA	0
@@ -14,7 +17,11 @@
 struct kiss {
 	mbuf_recv_fn send;
 	void *send_arg;
+	FILE *pcap_dump;
 };
+
+static int kiss_write_pcap_header(FILE *fp);
+static int kiss_pcap_dump(kiss *kiss, struct mbuf *bp);
 
 kiss *
 kiss_init(void)
@@ -25,6 +32,7 @@ kiss_init(void)
 
 	kiss->send = NULL;
 	kiss->send_arg = NULL;
+	kiss->pcap_dump = NULL;
 
 	return kiss;
 }
@@ -44,6 +52,8 @@ kiss_raw(kiss *dev, struct mbuf *data)
 	}
 	bp->data[0] = KISS_DATA;
 
+	kiss_pcap_dump(dev, bp);
+
 	return dev->send(dev->send_arg, bp);
 }
 
@@ -53,6 +63,8 @@ kiss_recv(void *devp, struct mbuf *bp)
 {
 	kiss *dev = (struct kiss *) devp;
 	char kisstype;
+
+	kiss_pcap_dump(dev, bp);
 
 	kisstype = pullchar(&bp);
 	ax25_dump(bp);
@@ -76,8 +88,108 @@ kiss_set_send(kiss *kiss, mbuf_recv_fn send_fn, void *send_arg)
 	return 0;
 }
 
+int
+kiss_set_pcap_dump(kiss *kiss, FILE *fp)
+{
+	int res;
+
+	if (kiss->pcap_dump != NULL) {
+		fclose(kiss->pcap_dump);
+		kiss->pcap_dump = NULL;
+	}
+
+	if (fp == NULL) {
+		return 0;
+	}
+
+	if (fseek(fp, 0, SEEK_END) != 0) {
+		return -1;
+	}
+
+	if (ftell(fp) != 0) {
+		if ((res = kiss_write_pcap_header(fp)) != 0) {
+			return res;
+		}
+	}
+
+	kiss->pcap_dump = fp;
+
+	return 0;
+}
+
+static int
+kiss_write_pcap_header(FILE *fp)
+{
+	struct pcap_header h;
+	int num;
+
+	h.magic_number = 0xa1b23c4d; /* Nanosecond-resolution type */
+	h.version_major = 2;
+	h.version_minor = 4;
+	h.this_zone = 0;
+	h.sigfigs = 0;
+	h.snaplen = 65536;
+	h.network = LINKTYPE_AX25_KISS;
+
+	num = fwrite(&h, sizeof(h), 1, fp);
+	fflush(fp);
+
+	return (num == 1) ? 0 : -1;
+}
+
+static int
+kiss_pcap_dump(kiss *kiss, struct mbuf *bp)
+{
+	struct mbuf *tbp;
+	struct pcap_packet_header_ns ph;
+	struct timeval tv;
+	int res;
+	size_t size;
+
+	if (kiss->pcap_dump == NULL) {
+		return 0;
+	}
+
+	if ((res = gettimeofday(&tv, NULL)) != 0) {
+		return res;
+	}
+
+	size = 0;
+	tbp = bp;
+	while (tbp != NULL) {
+		size += tbp->cnt;
+		tbp = tbp->next;
+	}
+
+	ph.tm_s = tv.tv_sec;
+	ph.tm_ns = tv.tv_usec * 1000;
+	ph.capture_length = size;
+	ph.packet_length = size;
+
+	if (fwrite(&ph, sizeof(ph), 1, kiss->pcap_dump) != 1) {
+		return -1;
+	}
+
+	tbp = bp;
+	while (tbp != NULL) {
+		res = fwrite(tbp->data, sizeof(char), tbp->cnt,
+			kiss->pcap_dump);
+		if (res != tbp->cnt) {
+			return -1;
+		}
+		tbp = tbp->next;
+	}
+
+	if (fflush(kiss->pcap_dump) != 0) {
+		return -1;
+	}
+
+	return 0;
+}
+
 void
 kiss_deinit(kiss *kiss)
 {
+	kiss_set_pcap_dump(kiss, NULL);
 	free(kiss);
 }

--- a/src/bbs/tncd/kiss.h
+++ b/src/bbs/tncd/kiss.h
@@ -1,11 +1,14 @@
 #ifndef _TNCD_KISS_H
 #define _TNCD_KISS_H
 
+#include <stdio.h>
+
 #include "calls.h"
 
 typedef struct kiss kiss;
 
 kiss *kiss_init(void);
+int kiss_set_pcap_dump(kiss *dev, FILE *fp);
 int kiss_raw(kiss *dev, struct mbuf *data);
 int kiss_recv(void *dev, struct mbuf *bp);
 int kiss_set_send(kiss *dev, mbuf_recv_fn send_fn, void *send_arg);

--- a/src/bbs/tncd/kiss_pcap.h
+++ b/src/bbs/tncd/kiss_pcap.h
@@ -1,0 +1,31 @@
+#ifndef _TNCD_KISS_PCAP_H
+#define _TNCD_KISS_PCAP_H
+
+#include <stdint.h>
+
+/* Tcpdump.org PCAP type */
+#define LINKTYPE_AX25_KISS	202
+
+/*
+ * The PCAP file header. Using clever runtime checking of the
+ * magic number field, this structure can be written to disk
+ * directly without care of the native CPU byte order.
+ */
+struct pcap_header {
+	uint32_t magic_number;
+	uint16_t version_major;
+	uint16_t version_minor;
+	int32_t	 this_zone;
+	uint32_t sigfigs;
+	uint32_t snaplen;
+	uint32_t network;
+};
+
+struct pcap_packet_header_ns {
+	uint32_t tm_s;
+	uint32_t tm_ns;
+	uint32_t packet_length;
+	uint32_t capture_length;
+};
+
+#endif


### PR DESCRIPTION
This PR adds the ability to configure TNCD to generate a PCAP packet capture file that records all packets received and transmitted on the TNC that it controls.