### PR TITLE
Convert bbsd to event-driven framework

### DIFF
--- a/src/bbs/bbsd/bbsd.h
+++ b/src/bbs/bbsd/bbsd.h
@@ -1,5 +1,6 @@
 #include <time.h>
 #include "smtp.h"
+#include "alib.h"
 
 #define Error(s)	"NO, "s"\n"
 #define Ok(s)		"OK, "s"\n"
@@ -30,6 +31,9 @@ struct active_processes {
 	int verbose;
 	char *text;
 	char call[10];
+	char buf[1024];
+	size_t sz;
+	alEventHandle ev;
 };
 
 extern struct active_processes *procs;

--- a/src/bbs/bbsd/main.c
+++ b/src/bbs/bbsd/main.c
@@ -316,7 +316,7 @@ main(int argc, char *argv[])
 		return 1;
 	}
 
-	AL_CALLBACK(&cb, NULL, accept_callback);
+	AL_CALLBACK(&cb, (void *)listen_sock, accept_callback);
 	if (alEvent_registerFd(listen_sock, ALFD_READ, cb, &listen_ev) != 0) {
 		fprintf(stderr, "Unable to register listen socket\n");
 		return 1;
@@ -369,7 +369,7 @@ accept_callback(void *ctx, void *arg0, int arg1)
 	char buf[80];
 	alCallback cb;
 
-	listen_sock = arg1;
+	listen_sock = (int) ctx;
 	fd = socket_accept(listen_sock);
 	if (fd < 0) {
 		fprintf(stderr, "accept failed on new connection.\n");


### PR DESCRIPTION
Convert bbsd, the central bbs orchestrator, from a manual select() polling loop to one that uses alib, my async event-based framework.

This change could potentially impact the "monitor" and "ping" features of the bbs daemon, both of which are not very well described in the documentation but are visible in the code. The impact is mostly around how often these callbacks are executed and the order in which they are executed.

The old code seemed to have a few hacks inserted to ensure that the daemon check timer and ping timer were put on a faster pace during BBS bringup, but the way it was coded was very non-deterministic in that these timers would only be called if the select() call returned no file descriptor activity.