### PR TITLE
Fix many database update routines to be crash safe.

### DIFF
--- a/src/bbs/bidd/bid.h
+++ b/src/bbs/bidd/bid.h
@@ -29,7 +29,8 @@ extern char
 extern int
 	read_file(char *filename),
 	read_new_file(char *filename),
-	hash_delete_bid(char *s);
+	hash_delete_bid(char *s),
+	hash_write(FILE *fp);
 
 extern struct bid_entry
 	*hash_get_bid(char *s),
@@ -50,7 +51,6 @@ extern char
 	*write_file(void),
 	*parse(char *s),
 	*hash_cnt(void),
-	*hash_write(FILE *fp),
 	*add_bid(char *bid),
 	*chk_bid(char *bid),
 	*chk_mid(char *bid),

--- a/src/bbs/bidd/hash.c
+++ b/src/bbs/bidd/hash.c
@@ -118,19 +118,22 @@ hash_delete_bid(char *s)
 	return ERROR;
 }
 
-char *
+int
 hash_write(FILE *fp)
 {
-	int i;
+	size_t i;
+	int res;
 
 	for(i=0; i<HASH_SIZE; i++) {
 		struct bid_entry *b = bid[i];
 		while(b) {
-			fprintf(fp, "+%s %"PRTMd"\n", b->str, b->seen);
+			res = fprintf(fp, "+%s %"PRTMd"\n", b->str, b->seen);
+			if (res < 0)
+				return res;
 			NEXT(b);
 		}
 	}
-	return "OK\n";
+	return 0;
 }
 
 char *

--- a/src/bbs/wpd/wp.h
+++ b/src/bbs/wpd/wp.h
@@ -130,7 +130,8 @@ int
 	hash_delete_user(char *s),
 	hash_delete_bbs(char *s),
 	hash_deleted_user(char *s),
-	hash_deleted_bbs(char *s);
+	hash_deleted_bbs(char *s),
+	hash_write(FILE *fp, int mode);
 
 char
 	*upload(char *cmd),
@@ -148,7 +149,6 @@ char
     *write_bbs_file(void),
 	*time2date(time_t t),
 	*time2udate(time_t t),
-	*hash_write(FILE *fp, int mode),
     *hash_bbs_cnt(void),
     *hash_user_cnt(void),
 	*report_entry(char *call),

--- a/src/tools/tools.h
+++ b/src/tools/tools.h
@@ -81,6 +81,7 @@ int
 	textline_count(struct text_line *tl),
 	textline_maxlength(struct text_line *tl),
 	spool_fclose(FILE *fp),					/* spool.c */
+	spool_abort(FILE *fp),					/* spool.c */
 	stricmp(char *s1, char *s2),			/* common.c */
 	read_sola(int *bv, int *iv, int *ov),	/* sola.c */
 	dectalk(char *str),						/* dectalk.c */


### PR DESCRIPTION
Fix issue #24 and many others like it by upgrading the existing "spool_fopen()", "spool_fclose()" framework and adhering to better error checking.

Many of the daemons in the BBS have fortunately being using a centralized "spool_xxx()" framework when updating text database files, but the framework lacked a rollback feature and even with it, none of its users were checking for corruption issues during their write/update cycles.

With this change, the framework now has a "spool_abort()" routine which can be called when a daemon realizes that it cannot write an update file correctly. Additionally, the framework now uses the standard "rename()" system call instead of the non-atomic "unlink/link" sequence it was using before.