### PR TITLE
Fix message listing reveral (issue #30).

### DIFF
--- a/src/bbs/bbs/msg_util.c
+++ b/src/bbs/bbs/msg_util.c
@@ -486,13 +486,14 @@ msg_parse(struct msg_dir_entry *m, char *s, int read_by_me)
 }
 
 static int
-msg_insert(struct msg_dir_entry *m, int num)
+msg_insert(struct msg_dir_entry *m, int new_num)
 {
-	struct msg_dir_entry *msg;
+	struct msg_dir_entry *cur;
+	int found_greater;
 
-	TAILQ_FOREACH_REVERSE(msg, &MsgDirList, msg_dir_list, entries) {
-		if (num < msg->number) {
-			TAILQ_INSERT_BEFORE(msg, m, entries);
+	TAILQ_FOREACH_REVERSE(cur, &MsgDirList, msg_dir_list, entries) {
+		if (cur->number < new_num) {
+			TAILQ_INSERT_AFTER(&MsgDirList, cur, m, entries);
 			return OK;
 		}
 	}


### PR DESCRIPTION
Fix a bug introduced by the linked-list clean up I perfomed a few weeks ago. While replacing hand-rolled list management I didn't quite translate the message list _building_ process correctly, causing the internal message list for users to be sorted in reverse order.

With this fix, message listings should display as they used to.